### PR TITLE
Downsample map

### DIFF
--- a/easynav_simple_common/include/easynav_simple_common/SimpleMap.hpp
+++ b/easynav_simple_common/include/easynav_simple_common/SimpleMap.hpp
@@ -193,6 +193,22 @@ public:
    */
   void print(bool view_data = false) const;
 
+  /**
+   * @brief Creates a downsampled version of the map by an integer factor.
+   *
+   * @param factor Integer factor (>1) to reduce resolution.
+   * @return A shared pointer to the new downsampled SimpleMap.
+   */
+  std::shared_ptr<SimpleMap> downsample_factor(int factor) const;
+
+  /**
+   * @brief Creates a downsampled version of the map to match a target resolution.
+   *
+   * @param new_resolution New desired resolution (must be a multiple of current).
+   * @return A shared pointer to the new downsampled SimpleMap.
+   */
+  std::shared_ptr<SimpleMap> downsample(double new_resolution) const;
+
 private:
   int width_;
   int height_;

--- a/easynav_simple_common/src/easynav_simple_common/SimpleMap.cpp
+++ b/easynav_simple_common/src/easynav_simple_common/SimpleMap.cpp
@@ -269,5 +269,54 @@ SimpleMap::print(bool view_data) const
   }
 }
 
+std::shared_ptr<SimpleMap>
+SimpleMap::downsample_factor(int factor) const
+{
+  if (factor <= 1) {
+    throw std::invalid_argument("Downsampling factor must be > 1");
+  }
+
+  int new_width = width_ / factor;
+  int new_height = height_ / factor;
+  double new_resolution = resolution_ * factor;
+
+  auto new_map = std::make_shared<SimpleMap>();
+  new_map->initialize(new_width, new_height, new_resolution, origin_x_, origin_y_, false);
+
+  for (int y = 0; y < new_height; ++y) {
+    for (int x = 0; x < new_width; ++x) {
+      int occupied_count = 0;
+      for (int dy = 0; dy < factor; ++dy) {
+        for (int dx = 0; dx < factor; ++dx) {
+          int src_x = x * factor + dx;
+          int src_y = y * factor + dy;
+          if (at(src_x, src_y)) {
+            occupied_count++;
+          }
+        }
+      }
+
+      new_map->at(x, y) = (occupied_count > (factor * factor / 2));
+    }
+  }
+
+  return new_map;
+}
+
+std::shared_ptr<SimpleMap>
+SimpleMap::downsample(double new_resolution) const
+{
+  if (new_resolution <= resolution_) {
+    throw std::invalid_argument("new_resolution must be greater than current resolution");
+  }
+
+  int factor = static_cast<int>(std::floor(new_resolution / resolution_));
+
+  if (factor < 1) {
+    factor = 1;
+  }
+
+  return downsample_factor(factor);
+}
 
 }  // namespace easynav

--- a/easynav_simple_common/tests/simple_maps_tests.cpp
+++ b/easynav_simple_common/tests/simple_maps_tests.cpp
@@ -138,3 +138,68 @@ TEST_F(SimpleMapTest, OccupancyGridConversion)
     }
   }
 }
+
+/// \brief Downsampling with integer factor
+TEST_F(SimpleMapTest, DownsampleIntegerFactor)
+{
+  easynav::SimpleMap map;
+  map.initialize(4, 4, 0.5, 0.0, 0.0);
+
+  map.at(0, 0) = true;
+  map.at(1, 0) = true;
+  map.at(1, 1) = true;
+  map.at(2, 2) = true;
+
+  auto downsampled = map.downsample_factor(2);
+  ASSERT_NE(downsampled, nullptr);
+
+  EXPECT_EQ(downsampled->width(), 2u);
+  EXPECT_EQ(downsampled->height(), 2u);
+  EXPECT_DOUBLE_EQ(downsampled->resolution(), 1.0);
+  EXPECT_DOUBLE_EQ(downsampled->origin_x(), 0.0);
+  EXPECT_DOUBLE_EQ(downsampled->origin_y(), 0.0);
+
+  EXPECT_TRUE(downsampled->at(0, 0));
+  EXPECT_FALSE(downsampled->at(1, 0));
+  EXPECT_FALSE(downsampled->at(0, 1));
+  EXPECT_FALSE(downsampled->at(1, 1));
+}
+
+/// \brief Downsampling to new resolution
+TEST_F(SimpleMapTest, DownsampleToResolution)
+{
+  easynav::SimpleMap map;
+  map.initialize(6, 6, 0.2, -1.0, -1.0);
+
+  map.at(1, 1) = true;
+  map.at(2, 2) = true;
+  map.at(4, 4) = true;
+  map.at(5, 5) = true;
+
+  auto downsampled = map.downsample(0.4);
+  ASSERT_NE(downsampled, nullptr);
+
+  EXPECT_EQ(downsampled->width(), 3u);
+  EXPECT_EQ(downsampled->height(), 3u);
+  EXPECT_DOUBLE_EQ(downsampled->resolution(), 0.4);
+  EXPECT_DOUBLE_EQ(downsampled->origin_x(), -1.0);
+  EXPECT_DOUBLE_EQ(downsampled->origin_y(), -1.0);
+
+  EXPECT_FALSE(downsampled->at(0, 0));
+  EXPECT_FALSE(downsampled->at(1, 1));
+  EXPECT_FALSE(downsampled->at(2, 2));
+}
+
+/// \brief Downsample that results in cropped edges
+TEST_F(SimpleMapTest, DownsampleWithCropping)
+{
+  easynav::SimpleMap map;
+  map.initialize(7, 7, 0.2, 0.0, 0.0);
+
+  map.at(6, 6) = true;
+
+  auto downsampled = map.downsample(0.7);
+
+  EXPECT_EQ(downsampled->width(), 2u);
+  EXPECT_EQ(downsampled->height(), 2u);
+}

--- a/easynav_simple_planner/src/easynav_simple_planner/SimplePlanner.cpp
+++ b/easynav_simple_planner/src/easynav_simple_planner/SimplePlanner.cpp
@@ -79,23 +79,25 @@ SimplePlanner::update(const NavState & nav_state)
   const auto & map = dynamic_cast<const SimpleMap &>(*nav_state.maps.at("simple.dynamic"));
   const auto & goal = nav_state.goals.goals.front().pose;
 
+  auto downsampled_map = map.downsample(0.2);
+
   if (nav_state.goals.header.frame_id != "map") {
     RCLCPP_WARN(get_node()->get_logger(),
       "SimplePlanner::update goals frame is not map (%s)", nav_state.goals.header.frame_id.c_str());
     return;
   }
 
-  if (!map.check_bounds_metric(goal.position.x, goal.position.y)) {
+  if (!downsampled_map->check_bounds_metric(goal.position.x, goal.position.y)) {
     RCLCPP_WARN(get_node()->get_logger(),
       "SimplePlanner::update goal (%lf, %lf) outside the map", goal.position.x, goal.position.y);
     return;
   }
 
   auto poses = a_star_path(
-    map,
+    *downsampled_map,
     nav_state.odom.pose.pose,
     goal,
-    map.resolution());
+    downsampled_map->resolution());
 
   if (!poses.empty()) {
     current_path_.header.stamp = get_node()->now();


### PR DESCRIPTION
Hi,

A* was taking too much time when the resolution is low. In this PR we add to SimpleMap methods to generate a downsampled map, which is used for path planning, drastically reducing the time to calculate paths.