### PR TITLE
Skip reseed if particles are not corrected

### DIFF
--- a/easynav_simple_localizer/src/easynav_simple_localizer/AMCLLocalizer.cpp
+++ b/easynav_simple_localizer/src/easynav_simple_localizer/AMCLLocalizer.cpp
@@ -418,6 +418,7 @@ void
 AMCLLocalizer::reseed()
 {
   if (particles_.empty()) {return;}
+  if (particles_[0].possible_hits == 0) {return;}
 
   const std::size_t N = particles_.size();
   const std::size_t N_top = N / 2;


### PR DESCRIPTION
Hi,

This PR prevents reseeding if the particles have not been corrected, due to no sensor information or a problem with the first TFs.

@Juancams , you should apply this to experiments.