### PR TITLE
Fix tf2_ros deprecation warnings

### DIFF
--- a/.github/thirdparty.repos
+++ b/.github/thirdparty.repos
@@ -1,4 +1,8 @@
 repositories:
+  ThirdParty/yaets:
+    type: git
+    url: https://github.com/fmrico/yaets.git
+    version: rolling
   ThirdParty/EasyNavigation:
     type: git
     url: https://github.com/EasyNavigation/EasyNavigation.git

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# VS Code stuff 
+/.vscode/**
+
+# Python stuff
+**/__pycache__/
+
+# Colcon mistakes
+build/
+install/
+log/

--- a/easynav_simple_localizer/include/easynav_simple_localizer/AMCLLocalizer.hpp
+++ b/easynav_simple_localizer/include/easynav_simple_localizer/AMCLLocalizer.hpp
@@ -37,7 +37,7 @@
 #include "nav_msgs/msg/odometry.hpp"
 
 #include "tf2/LinearMath/Transform.hpp"
-#include "tf2_ros/transform_broadcaster.h"
+#include "tf2_ros/transform_broadcaster.hpp"
 
 #include "easynav_core/LocalizerMethodBase.hpp"
 

--- a/easynav_simple_maps_manager/include/easynav_simple_maps_manager/SimpleMapsManager.hpp
+++ b/easynav_simple_maps_manager/include/easynav_simple_maps_manager/SimpleMapsManager.hpp
@@ -33,8 +33,8 @@
 #include "nav_msgs/msg/occupancy_grid.hpp"
 #include "std_srvs/srv/trigger.hpp"
 
-#include "tf2_ros/buffer.h"
-#include "tf2_ros/transform_listener.h"
+#include "tf2_ros/buffer.hpp"
+#include "tf2_ros/transform_listener.hpp"
 
 #include "easynav_core/MapsManagerBase.hpp"
 #include "easynav_simple_common/SimpleMap.hpp"

--- a/easynav_simple_maps_manager/tests/simple_mapsmanager_tests.cpp
+++ b/easynav_simple_maps_manager/tests/simple_mapsmanager_tests.cpp
@@ -69,7 +69,7 @@ TEST_F(SimpleMapsManagerTest, BasicDynamicUpdate)
   manager->initialize(node, "test");
 
   auto tf_buffer = easynav::RTTFBuffer::getInstance(node->get_clock());
-  tf2_ros::TransformListener tf_listener(*tf_buffer, node, true);
+  tf2_ros::TransformListener tf_listener(*tf_buffer, *node, true);
 
   easynav::SimpleMap static_map;
   static_map.initialize(30, 30, 0.1, -1.5, -1.5, 0.0);


### PR DESCRIPTION
Using `.hpp` headers for `tf2_ros` stuff instead of `.h` (deprecated) headers. Should work at least up to jazzy.